### PR TITLE
added required args param to cordova.exec calls

### DIFF
--- a/www/QRScanner.js
+++ b/www/QRScanner.js
@@ -151,10 +151,10 @@ function doneCallback(callback, clear) {
 
 var QRScanner = {
   prepare: function(callback) {
-    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'prepare');
+    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'prepare', []);
   },
   destroy: function(callback) {
-    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'destroy');
+    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'destroy', []);
   },
   scan: function(callback) {
     if (!callback) {
@@ -163,28 +163,28 @@ var QRScanner = {
     var success = function(result) {
       callback(null, result);
     };
-    cordova.exec(success, errorCallback(callback), 'QRScanner', 'scan');
+    cordova.exec(success, errorCallback(callback), 'QRScanner', 'scan', []);
   },
   cancelScan: function(callback) {
-    cordova.exec(doneCallback(callback), null, 'QRScanner', 'cancelScan');
+    cordova.exec(doneCallback(callback), null, 'QRScanner', 'cancelScan', []);
   },
   show: function(callback) {
-    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'show');
+    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'show', []);
   },
   hide: function(callback) {
-    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'hide');
+    cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'hide', []);
   },
   pausePreview: function(callback) {
-    cordova.exec(doneCallback(callback), null, 'QRScanner', 'pausePreview');
+    cordova.exec(doneCallback(callback), null, 'QRScanner', 'pausePreview', []);
   },
   resumePreview: function(callback) {
-    cordova.exec(doneCallback(callback), null, 'QRScanner', 'resumePreview');
+    cordova.exec(doneCallback(callback), null, 'QRScanner', 'resumePreview', []);
   },
   enableLight: function(callback) {
-    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'enableLight');
+    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'enableLight', []);
   },
   disableLight: function(callback) {
-    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'disableLight');
+    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'disableLight', []);
   },
   useCamera: function(index, callback) {
     cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'useCamera', [index]);
@@ -207,16 +207,16 @@ var QRScanner = {
   },
   openSettings: function(callback) {
     if (callback) {
-      cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'openSettings');
+      cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'openSettings', []);
     } else {
-      cordova.exec(null, null, 'QRScanner', 'openSettings');
+      cordova.exec(null, null, 'QRScanner', 'openSettings', []);
     }
   },
   getStatus: function(callback) {
     if (!callback) {
       throw new Error('No callback provided to getStatus method.');
     }
-    cordova.exec(doneCallback(callback), null, 'QRScanner', 'getStatus');
+    cordova.exec(doneCallback(callback), null, 'QRScanner', 'getStatus', []);
   }
 };
 


### PR DESCRIPTION
Args is a required, final parameter to the `cordova.exec()` call. When absent in recent versions of cordova, the app crashes because `cordova.exec` tries to loop through the args array but JavaScript "Cannot read property 'length of undefined". 

I added an empty array to all `exec` calls wherever the args param was omitted.

My version of Cordova is 5.4.1, FYI.