### PR TITLE
Remove unnecessary dependency (breaks other plugins)

### DIFF
--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -59,7 +59,8 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
     private boolean restricted;
     private boolean oneTime = true;
     private boolean keepDenied = false;
-
+    private boolean appPausedWithActivePreview = false;
+    
     static class QRScannerError {
         private static final int UNEXPECTED_ERROR = 0,
                 CAMERA_ACCESS_DENIED = 1,
@@ -217,6 +218,22 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         } catch (Exception e) {
             callbackContext.error(QRScannerError.UNEXPECTED_ERROR);
             return false;
+        }
+    }
+
+    @Override
+    public void onPause(boolean multitasking) {
+        if (previewing) {
+            this.appPausedWithActivePreview = true;
+            this.pausePreview(null);
+        }
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        if (this.appPausedWithActivePreview) {
+            this.appPausedWithActivePreview = false;
+            this.resumePreview(null);
         }
     }
 
@@ -624,7 +641,9 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                     if(lightOn)
                         lightOn = false;
                 }
-                getStatus(callbackContext);
+                
+                if (callbackContext != null)
+                    getStatus(callbackContext);
             }
         });
 
@@ -640,7 +659,9 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                     if(switchFlashOn)
                         lightOn = true;
                 }
-                getStatus(callbackContext);
+                
+                if (callbackContext != null)
+                    getStatus(callbackContext);
             }
         });
     }

--- a/src/android/qrscanner.gradle
+++ b/src/android/qrscanner.gradle
@@ -5,7 +5,6 @@ repositories {
 dependencies {
     compile 'com.journeyapps:zxing-android-embedded:3.3.0'
     compile 'com.android.support:appcompat-v7:23.1.0'
-    compile 'com.google.android.gms:play-services:7.8+'
 }
 
 android {


### PR DESCRIPTION
Hi,

this removes an unnecessary dependency to Google Play Services.
It's not only **not** needed, but breaking the build with other plugins (like phonegap-plugin-push or cordova-plugin-google-analytics). The error is decribed here: http://stackoverflow.com/questions/31224276/multiple-dex-files-define-lcom-google-android-gms-internal-zzau

As the Android version does not need this, just removing it fixes it.