### PR TITLE
feat(ios): Upgrade, convert syntax to Swift 3.1

### DIFF
--- a/src/ios/QRScanner.swift
+++ b/src/ios/QRScanner.swift
@@ -7,7 +7,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
     class CameraView: UIView {
         var videoPreviewLayer:AVCaptureVideoPreviewLayer?
         
-        func interfaceOrientationToVideoOrientation(orientation : UIInterfaceOrientation) -> AVCaptureVideoOrientation {
+        func interfaceOrientationToVideoOrientation(_ orientation : UIInterfaceOrientation) -> AVCaptureVideoOrientation {
             switch (orientation) {
             case UIInterfaceOrientation.portrait:
                 return AVCaptureVideoOrientation.portrait;
@@ -30,11 +30,11 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 }
             }
             
-            self.videoPreviewLayer?.connection.videoOrientation = interfaceOrientationToVideoOrientation(orientation:  UIApplication.shared.statusBarOrientation);
+            self.videoPreviewLayer?.connection.videoOrientation = interfaceOrientationToVideoOrientation(UIApplication.shared.statusBarOrientation);
         }
         
         
-        func addPreviewLayer(previewLayer:AVCaptureVideoPreviewLayer?) {
+        func addPreviewLayer(_ previewLayer:AVCaptureVideoPreviewLayer?) {
             previewLayer!.videoGravity = AVLayerVideoGravityResizeAspectFill
             previewLayer!.frame = self.bounds
             self.layer.addSublayer(previewLayer!)
@@ -61,15 +61,15 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
     var nextScanningCommand: CDVInvokedUrlCommand?
 
     enum QRScannerError: Int32 {
-        case UNEXPECTED_ERROR = 0,
-        CAMERA_ACCESS_DENIED = 1,
-        CAMERA_ACCESS_RESTRICTED = 2,
-        BACK_CAMERA_UNAVAILABLE = 3,
-        FRONT_CAMERA_UNAVAILABLE = 4,
-        CAMERA_UNAVAILABLE = 5,
-        SCAN_CANCELED = 6,
-        LIGHT_UNAVAILABLE = 7,
-        OPEN_SETTINGS_UNAVAILABLE = 8
+        case unexpected_error = 0,
+        camera_access_denied = 1,
+        camera_access_restricted = 2,
+        back_camera_unavailable = 3,
+        front_camera_unavailable = 4,
+        camera_unavailable = 5,
+        scan_canceled = 6,
+        light_unavailable = 7,
+        open_settings_unavailable = 8
     }
 
     enum CaptureError: Error {
@@ -121,10 +121,10 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
     func prepScanner(command: CDVInvokedUrlCommand) -> Bool{
         let status = AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo)
         if (status == AVAuthorizationStatus.restricted) {
-            self.sendErrorCode(command: command, error: QRScannerError.CAMERA_ACCESS_RESTRICTED)
+            self.sendErrorCode(command: command, error: QRScannerError.camera_access_restricted)
             return false
         } else if status == AVAuthorizationStatus.denied {
-            self.sendErrorCode(command: command, error: QRScannerError.CAMERA_ACCESS_DENIED)
+            self.sendErrorCode(command: command, error: QRScannerError.camera_access_denied)
             return false
         }
         do {
@@ -153,19 +153,19 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 metaOutput!.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
                 metaOutput!.metadataObjectTypes = [AVMetadataObjectTypeQRCode]
                 captureVideoPreviewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
-                cameraView.addPreviewLayer(previewLayer: captureVideoPreviewLayer)
+                cameraView.addPreviewLayer(captureVideoPreviewLayer)
                 captureSession!.startRunning()
             }
             return true
         } catch CaptureError.backCameraUnavailable {
-            self.sendErrorCode(command: command, error: QRScannerError.BACK_CAMERA_UNAVAILABLE)
+            self.sendErrorCode(command: command, error: QRScannerError.back_camera_unavailable)
         } catch CaptureError.frontCameraUnavailable {
-            self.sendErrorCode(command: command, error: QRScannerError.FRONT_CAMERA_UNAVAILABLE)
+            self.sendErrorCode(command: command, error: QRScannerError.front_camera_unavailable)
         } catch CaptureError.couldNotCaptureInput(let error){
             print(error.localizedDescription)
-            self.sendErrorCode(command: command, error: QRScannerError.CAMERA_UNAVAILABLE)
+            self.sendErrorCode(command: command, error: QRScannerError.camera_unavailable)
         } catch {
-            self.sendErrorCode(command: command, error: QRScannerError.UNEXPECTED_ERROR)
+            self.sendErrorCode(command: command, error: QRScannerError.unexpected_error)
         }
         return false
     }
@@ -222,10 +222,10 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
             backCamera!.unlockForConfiguration()
             self.getStatus(command)
         } catch LightError.torchUnavailable {
-            self.sendErrorCode(command: command, error: QRScannerError.LIGHT_UNAVAILABLE)
+            self.sendErrorCode(command: command, error: QRScannerError.light_unavailable)
         } catch let error as NSError {
             print(error.localizedDescription)
-            self.sendErrorCode(command: command, error: QRScannerError.UNEXPECTED_ERROR)
+            self.sendErrorCode(command: command, error: QRScannerError.unexpected_error)
         }
     }
 
@@ -281,7 +281,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
         if(self.prepScanner(command: command)){
             scanning = false
             if(nextScanningCommand != nil){
-                self.sendErrorCode(command: nextScanningCommand!, error: QRScannerError.SCAN_CANCELED)
+                self.sendErrorCode(command: nextScanningCommand!, error: QRScannerError.scan_canceled)
             }
             self.getStatus(command)
         }
@@ -335,22 +335,22 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
                         captureSession!.commitConfiguration()
                         self.getStatus(command)
                     } catch CaptureError.backCameraUnavailable {
-                        self.sendErrorCode(command: command, error: QRScannerError.BACK_CAMERA_UNAVAILABLE)
+                        self.sendErrorCode(command: command, error: QRScannerError.back_camera_unavailable)
                     } catch CaptureError.frontCameraUnavailable {
-                        self.sendErrorCode(command: command, error: QRScannerError.FRONT_CAMERA_UNAVAILABLE)
+                        self.sendErrorCode(command: command, error: QRScannerError.front_camera_unavailable)
                     } catch CaptureError.couldNotCaptureInput(let error){
                         print(error.localizedDescription)
-                        self.sendErrorCode(command: command, error: QRScannerError.CAMERA_UNAVAILABLE)
+                        self.sendErrorCode(command: command, error: QRScannerError.camera_unavailable)
                     } catch {
-                        self.sendErrorCode(command: command, error: QRScannerError.UNEXPECTED_ERROR)
+                        self.sendErrorCode(command: command, error: QRScannerError.unexpected_error)
                     }
 
                 }
             } else {
                 if(backCamera == nil){
-                    self.sendErrorCode(command: command, error: QRScannerError.BACK_CAMERA_UNAVAILABLE)
+                    self.sendErrorCode(command: command, error: QRScannerError.back_camera_unavailable)
                 } else {
-                    self.sendErrorCode(command: command, error: QRScannerError.FRONT_CAMERA_UNAVAILABLE)
+                    self.sendErrorCode(command: command, error: QRScannerError.front_camera_unavailable)
                 }
             }
         } else {
@@ -474,7 +474,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 self.getStatus(command)
             })
         } else {
-            self.sendErrorCode(command: command, error: QRScannerError.OPEN_SETTINGS_UNAVAILABLE)
+            self.sendErrorCode(command: command, error: QRScannerError.open_settings_unavailable)
             }
         } else {
         // pre iOS 10.0
@@ -482,7 +482,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
                 UIApplication.shared.openURL(NSURL(string: UIApplicationOpenSettingsURLString)! as URL)
                 self.getStatus(command)
             } else {
-                self.sendErrorCode(command: command, error: QRScannerError.OPEN_SETTINGS_UNAVAILABLE)
+                self.sendErrorCode(command: command, error: QRScannerError.open_settings_unavailable)
             }
         }
     }


### PR DESCRIPTION
Update to the latest syntax for Swift 3.1 (suppresses warnings/"convert syntax" dialog when opening project in XCode)