### PR TITLE
Remove cordova-plugin-compat android dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,6 @@
       <uses-feature android:name="android.hardware.camera.front" android:required="false" />
     </config-file>
     <source-file src="src/android/QRScanner.java" target-dir="src/com/bitpay/cordova/qrscanner"/>
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
     <framework src="src/android/qrscanner.gradle" custom="true" type="gradleReference"/>
   </platform>
 


### PR DESCRIPTION
[cordova-plugin-compat](https://github.com/apache/cordova-plugin-compat) is deprecated and is included by default since `cordova-android` `6.3.0`

I think it's safe to remove it as an Android dependency because the projects that still need it can still add it as their dependency, rather than make it a transitive dependency of `cordova-plugin-qrscanner`.