### PR TITLE
Fixes Issue #181: Hide not properly hiding setting background transparency

### DIFF
--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -425,7 +425,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         this.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                webView.getView().setBackgroundColor(Color.TRANSPARENT);
+                webView.getView().setBackgroundColor(Color.WHITE);
             }
         });
         showing = false;
@@ -619,7 +619,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         this.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                webView.getView().setBackgroundColor(Color.argb(1, 0, 0, 0));
+                webView.getView().setBackgroundColor(Color.TRANSPARENT);
                 showing = true;
                 getStatus(callbackContext);
             }


### PR DESCRIPTION
Seems that the colors set for `Show` an `Hide` were inverted.
Fixed according to documented behavior.