### PR TITLE
Fixed add-swift-support dependency version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@
         <param name="ios-package" value="QRScanner"/>
       </feature>
     </config-file>
-    <dependency id="cordova-plugin-add-swift-support" spec="~1.7.2" />
+    <dependency id="cordova-plugin-add-swift-support" version="~1.7.2" />
     <source-file src="src/ios/QRScanner.swift"/>
     <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
       <string>The camera is used to scan QR codes.</string>


### PR DESCRIPTION
We were using 2.6.0 of this plugin which referenced add-swift-support in a way which did not limit the version number; since add-swift-support has upgraded a major version this stopped working.

This PR changes the way in which the dependency is referenced based on the Cordova plugin.xml documentation.

Could you please release version 2.6.3 with this change, which would allow us to continue using this plugin?

I know 3.x is already out, but we're not ready for the Swift 5 move yet.