### PR TITLE
Fixed a swift compilation error

### DIFF
--- a/src/ios/QRScanner.swift
+++ b/src/ios/QRScanner.swift
@@ -468,7 +468,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
 
     @objc func openSettings(_ command: CDVInvokedUrlCommand) {
         if #available(iOS 10.0, *) {
-            guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+            guard let settingsUrl = URL(string: UIApplicationOpenSettingsURLString) else {
             return
         }
         if UIApplication.shared.canOpenURL(settingsUrl) {
@@ -481,7 +481,7 @@ class QRScanner : CDVPlugin, AVCaptureMetadataOutputObjectsDelegate {
         } else {
             // pre iOS 10.0
             if #available(iOS 8.0, *) {
-                UIApplication.shared.openURL(NSURL(string: UIApplication.openSettingsURLString)! as URL)
+                UIApplication.shared.openURL(NSURL(string: UIApplicationOpenSettingsURLString)! as URL)
                 self.getStatus(command)
             } else {
                 self.sendErrorCode(command: command, error: QRScannerError.open_settings_unavailable)


### PR DESCRIPTION
Fixed the following error:

`QRScanner.swift:484:74: 'openSettingsURLString' has been renamed to 'UIApplicationOpenSettingsURLString'`

`UIApplication.openSettingsURLString` should be the way to do it in Swift 5, but it doesn't seem to work. UIApplicationOpenSettingsURLString however does work.

It's a temporary solution but it at least makes things work.