### PR TITLE
feat(ios,android): Adds support for barcodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-qrscanner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -29,6 +29,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +61,8 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
     private boolean oneTime = true;
     private boolean keepDenied = false;
     private boolean appPausedWithActivePreview = false;
-    
+    private ArrayList<BarcodeFormat> formatList = new ArrayList<BarcodeFormat>(Arrays.asList(BarcodeFormat.QR_CODE));
+
     static class QRScannerError {
         private static final int UNEXPECTED_ERROR = 0,
                 CAMERA_ACCESS_DENIED = 1,
@@ -71,6 +73,77 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                 SCAN_CANCELED = 6,
                 LIGHT_UNAVAILABLE = 7,
                 OPEN_SETTINGS_UNAVAILABLE = 8;
+    }
+
+    private void configure(Object options) {
+        if (options instanceof JSONObject) {
+            JSONObject opt = (JSONObject) options;
+            if (opt.has("formats")) {
+                try {
+                    JSONArray formats = opt.getJSONArray("formats");
+                    ArrayList<BarcodeFormat> newFormats = new ArrayList<>();
+
+                    for (int i = 0; i < formats.length(); i++) {
+                        String format = formats.getString(i);
+                        switch (format) {
+                            case "QR_CODE":
+                                newFormats.add(BarcodeFormat.QR_CODE);
+                                break;
+
+                            case "DATA_MATRIX":
+                                newFormats.add(BarcodeFormat.DATA_MATRIX);
+                                break;
+
+                            case "UPC_E":
+                                newFormats.add(BarcodeFormat.UPC_E);
+                                break;
+
+                            case "EAN_8":
+                                newFormats.add(BarcodeFormat.EAN_8);
+                                break;
+
+                            case "EAN_13":
+                                newFormats.add(BarcodeFormat.EAN_13);
+                                break;
+
+                            case "CODE_39":
+                                newFormats.add(BarcodeFormat.CODE_39);
+                                break;
+
+                            case "CODE_93":
+                                newFormats.add(BarcodeFormat.CODE_93);
+                                break;
+
+                            case "CODE_128":
+                                newFormats.add(BarcodeFormat.CODE_128);
+                                break;
+
+                            case "ITF":
+                                newFormats.add(BarcodeFormat.ITF);
+                                break;
+
+                            case "PDF_417":
+                                newFormats.add(BarcodeFormat.PDF_417);
+                                break;
+
+                            case "AZTEC":
+                                newFormats.add(BarcodeFormat.AZTEC);
+                                break;
+                        }
+                    }
+                    formatList = newFormats;
+                } catch (Exception e) {
+                    //ignore
+                }
+            }
+
+            if (opt.has("camera")) {
+                try {
+                    currentCameraId = opt.getInt("camera");
+                } catch (JSONException ignored) {
+                }
+            }
+        }
     }
 
     @Override
@@ -86,6 +159,8 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                 return true;
             }
             else if(action.equals("scan")) {
+                if (args.length() > 0)
+                    configure(args.get(0));
                 cordova.getThreadPool().execute(new Runnable() {
                     public void run() {
                         scan(callbackContext);
@@ -180,15 +255,13 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                 return true;
             }
             else if (action.equals("prepare")) {
+                if (args.length() > 0)
+                    configure(args.get(0));
                 cordova.getThreadPool().execute(new Runnable() {
                     public void run() {
                         cordova.getActivity().runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                try {
-                                    currentCameraId = args.getInt(0);
-                                } catch (JSONException e) {
-                                }
                                 prepare(callbackContext);
                             }
                         });
@@ -453,11 +526,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                 // Create our Preview view and set it as the content of our activity.
                 mBarcodeView = new BarcodeView(cordova.getActivity());
 
-                //Configure the decoder
-                ArrayList<BarcodeFormat> formatList = new ArrayList<BarcodeFormat>();
-                formatList.add(BarcodeFormat.QR_CODE);
                 mBarcodeView.setDecoderFactory(new DefaultDecoderFactory(formatList, null, null));
-
                 //Configure the camera (front/back)
                 CameraSettings settings = new CameraSettings();
                 settings.setRequestedCameraId(getCurrentCameraId());
@@ -474,9 +543,8 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         });
         prepared = true;
         previewing = true;
-        if(shouldScanAgain)
+        if (shouldScanAgain)
             scan(callbackContext);
-
     }
 
     @Override
@@ -641,7 +709,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                     if(lightOn)
                         lightOn = false;
                 }
-                
+
                 if (callbackContext != null)
                     getStatus(callbackContext);
             }
@@ -659,7 +727,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
                     if(switchFlashOn)
                         lightOn = true;
                 }
-                
+
                 if (callbackContext != null)
                     getStatus(callbackContext);
             }
@@ -788,6 +856,7 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
         }
         closeCamera();
         currentCameraId = 0;
+        formatList = new ArrayList<BarcodeFormat>(Arrays.asList(BarcodeFormat.QR_CODE));
         getStatus(callbackContext);
     }
 }

--- a/src/common/src/createQRScannerAdapter.js
+++ b/src/common/src/createQRScannerAdapter.js
@@ -154,20 +154,20 @@ function doneCallback(callback, clear) {
 }
 
 return {
-  prepare: function(callback) {
-    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'prepare', []);
+  prepare: function(callback, options) {
+    cordova.exec(successCallback(callback), errorCallback(callback), 'QRScanner', 'prepare', options ? [options] : []);
   },
   destroy: function(callback) {
     cordova.exec(doneCallback(callback, true), null, 'QRScanner', 'destroy', []);
   },
-  scan: function(callback) {
+  scan: function(callback, options) {
     if (!callback) {
       throw new Error('No callback provided to scan method.');
     }
     var success = function(result) {
       callback(null, result);
     };
-    cordova.exec(success, errorCallback(callback), 'QRScanner', 'scan', []);
+    cordova.exec(success, errorCallback(callback), 'QRScanner', 'scan', options ? [options] : []);
   },
   cancelScan: function(callback) {
     cordova.exec(doneCallback(callback), null, 'QRScanner', 'cancelScan', []);


### PR DESCRIPTION
This PR adds support for scanning barcodes of various formats. You can use it like this:

```
            QRScanner.prepare((err, status) => {
                // ...
            }, { formats: [ 'CODE_128', 'QR_CODE', 'EAN_13' ] });
```

or:

```
            QRScanner.scan((err, text) => {
                // ...
            }, { formats: [ 'AZTEC', 'QR_CODE', 'PDF_417' ] });
```

If options object is not provided, it behaves exactly as the original (only QR codes are being recognized).

