### PR TITLE
Update gradle file to support Gradle 7+

### DIFF
--- a/src/android/qrscanner.gradle
+++ b/src/android/qrscanner.gradle
@@ -3,8 +3,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.journeyapps:zxing-android-embedded:3.3.0'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    implementation 'com.journeyapps:zxing-android-embedded:3.3.0'
+    implementation 'com.android.support:appcompat-v7:23.1.0'
 }
 
 android {


### PR DESCRIPTION
compile is deprecated and removed since Gradle 7, in favor of 'implementation'.